### PR TITLE
Fixed missed call to Dispose method of class AmazonSqs

### DIFF
--- a/src/SimpleAmazonSQS/ISimpleAmazonQueueService.cs
+++ b/src/SimpleAmazonSQS/ISimpleAmazonQueueService.cs
@@ -1,8 +1,9 @@
+using System;
 using System.Collections.Generic;
 
 namespace SimpleAmazonSQS
 {
-    public interface ISimpleAmazonQueueService<T>
+    public interface ISimpleAmazonQueueService<T> : IDisposable
     {
         void Enqueue(T id);
         void DeleteMessage(string receiptHandle);

--- a/src/SimpleAmazonSQS/SimpleAmazonQueueService.cs
+++ b/src/SimpleAmazonSQS/SimpleAmazonQueueService.cs
@@ -10,7 +10,7 @@ using SimpleAmazonSQS.Converters;
 
 namespace SimpleAmazonSQS
 {
-    public class SimpleAmazonQueueService<T> : ISimpleAmazonQueueService<T>
+    public class SimpleAmazonQueueService<T> : ISimpleAmazonQueueService<T>, IDisposable
     {
         private readonly IConfiguration _configuration;
         private readonly IAmazonSQS _amazonSqsClient;
@@ -124,6 +124,14 @@ namespace SimpleAmazonSQS
 
             if (response == null) return 0;
             return response.ApproximateNumberOfMessages;
+        }
+
+        public void Dispose()
+        {
+            if (_amazonSqsClient != null)
+            {
+                _amazonSqsClient.Dispose();
+            }
         }
     }
 }

--- a/test/SimpleAmazonSQS.Tests/SimpleAmazonQueueServiceTests.cs
+++ b/test/SimpleAmazonSQS.Tests/SimpleAmazonQueueServiceTests.cs
@@ -170,6 +170,17 @@ namespace SimpleAmazonSQS.Tests
                 Times.Once()
             );
         }
+
+        [Test]
+        public void Dispose_ShouldCallDisposeOnAmazonClient()
+        {
+            _simpleAmazonQueueService.Dispose();
+
+            _fakeAmazonSqs.Verify(mock =>
+                mock.Dispose(),
+                Times.Once()
+            );
+        }
     }
 }
 

--- a/test/SimpleAmazonSQS.Tests/SimpleAmazonSQS.Tests.csproj
+++ b/test/SimpleAmazonSQS.Tests/SimpleAmazonSQS.Tests.csproj
@@ -84,7 +84,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
There was an issue related to a missing Dispose call. That issue can lead to memory leak. 